### PR TITLE
Fix logging of exceptions

### DIFF
--- a/lib/shared/exceptions.js
+++ b/lib/shared/exceptions.js
@@ -95,7 +95,9 @@ exports.BadRequest = function(msg, extra) {
     this.code    = 400;
     this.type    = "BadRequest";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.BadRequest.prototype = new exports.jsDAV_Exception();
 
@@ -109,7 +111,9 @@ exports.Conflict = function(msg, extra) {
     this.code    = 409;
     this.type    = "Conflict";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.Conflict.prototype = new exports.jsDAV_Exception();
 
@@ -145,7 +149,9 @@ exports.Locked = function(lock) {
     this.code = 423;
     this.type = this.message = "Locked";
     this.lock = lock;
-    console.log("Exception: ", this);
+    if (typeof lock !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 
     this.serialize = function(handler, errorNode) {
         if (this.lock) {
@@ -188,7 +194,9 @@ exports.FileNotFound = function(msg, extra) {
     this.code    = 404;
     this.type    = "FileNotFound";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.FileNotFound.prototype = new exports.jsDAV_Exception();
 
@@ -202,7 +210,9 @@ exports.Forbidden = function(msg, extra) {
     this.code    = 403;
     this.type    = "Forbidden";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.Forbidden.prototype = new exports.jsDAV_Exception();
 
@@ -264,7 +274,9 @@ exports.InsufficientStorage = function(msg, extra) {
     this.code    = 507;
     this.type    = "InsufficientStorage";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.InsufficientStorage.prototype = new exports.jsDAV_Exception();
 
@@ -310,7 +322,9 @@ exports.MethodNotAllowed = function(msg, extra) {
     this.code    = 405;
     this.type    = "MethodNotAllowed";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 
     this.getHTTPHeaders = function(handler, cbmethods) {
         handler.getAllowedMethods(handler.getRequestUri(), function(err, methods) {
@@ -332,7 +346,9 @@ exports.NotAuthenticated = function(msg, extra) {
     this.code    = 401;
     this.type    = "NotAuthenticated";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
     this.headers = {};
 
     this.addHeader = function(name, value) {
@@ -355,7 +371,9 @@ exports.NotImplemented = function(msg, extra) {
     this.code    = 501;
     this.type    = "NotImplemented";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.NotImplemented.prototype = new exports.jsDAV_Exception();
 
@@ -369,7 +387,9 @@ exports.PaymentRequired = function(msg, extra) {
     this.code    = 402;
     this.type    = "PaymentRequired";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.PaymentRequired.prototype = new exports.jsDAV_Exception();
 
@@ -385,7 +405,9 @@ exports.PreconditionFailed = function(msg, extra) {
     this.type    = "PreconditionFailed";
     this.message = msg || this.type;
     this.header  = extra;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 
     this.serialize = function(handler, errorNode) {
         return this.header
@@ -513,6 +535,8 @@ exports.UnsupportedMediaType = function(msg, extra) {
     this.code    = 415;
     this.type    = "UnsupportedMediaType";
     this.message = msg || this.type;
-    console.log("Exception: ", this);
+    if (typeof msg !== 'undefined') {
+      console.error("Exception: ", this);
+    }
 };
 exports.UnsupportedMediaType.prototype = new exports.jsDAV_Exception();


### PR DESCRIPTION
When starting Sync, we logged some exceptions that should not have been (created by JS inheritance).
This should cleanup the logs