### PR TITLE
Remove error message on objects creation

### DIFF
--- a/lib/CalDAV/plugin.js
+++ b/lib/CalDAV/plugin.js
@@ -374,11 +374,13 @@ var jsCalDAV_Plugin = module.exports = jsDAV_Plugin.extend({
         if (!parentNode.hasFeature(jsCalDAV_iCalendar))
             return e.next();
 
-        try {
-            this.validateICal(data);
-        }
-        catch (ex) {
-            return e.next(ex);
+        if (data !== null) {
+            try {
+                this.validateICal(data);
+            }
+            catch (ex) {
+                return e.next(ex);
+            }
         }
 
         e.next();

--- a/lib/CardDAV/plugin.js
+++ b/lib/CardDAV/plugin.js
@@ -374,11 +374,13 @@ var jsCardDAV_Plugin = module.exports = jsDAV_Plugin.extend({
         if (!parentNode.hasFeature(jsCardDAV_iAddressBook))
             return e.next();
 
-        try {
-            this.validateVCard(data);
-        }
-        catch (ex) {
-            return e.next(ex);
+        if (data !== null) {
+            try {
+                this.validateVCard(data);
+            }
+            catch (ex) {
+                return e.next(ex);
+            }
         }
 
         e.next();


### PR DESCRIPTION
When creating a new object (event or contact), we tried to validate an empty object, which resulted in an error message in server logs.